### PR TITLE
feat: update spans with currentYear class to display the current year

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -760,4 +760,10 @@ document.addEventListener("DOMContentLoaded", () => {
   window.addEventListener("resize", () => {
       updateTrackWidth();
   });
+
+  const spanCurrentYears = document.querySelectorAll(".currentYear")
+
+  spanCurrentYears.forEach(span => {
+    span.innerText = new Date().getFullYear()
+  })
 });

--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
         <div class="footer-bottom">
             <p><i class="fas fa-envelope"></i> <a href="mailto:info@uzzo.solutions">info@uzzo.solutions</a></p>
             <p><i class="fas fa-phone-alt"></i> (64) 98171-8495</p>
-            <p>Uzzo Solutions - 2024</p>
+            <p>Uzzo Solutions - <span class="currentYear">0000</span></p>
         </div>
     </footer>
 


### PR DESCRIPTION
This feature automatically updates all spans with the currentYear class to display the current year, eliminating the need for manual updates.

![image](https://github.com/user-attachments/assets/19d27f43-4bd6-42c4-b7e9-687c5259ba3a)
